### PR TITLE
IOClientLauncher.java: fix bug with framerate

### DIFF
--- a/Client/src/IOClientLauncher.java
+++ b/Client/src/IOClientLauncher.java
@@ -1,0 +1,13 @@
+package io.client;
+
+import javafx.application.Application;
+
+// this is the only way to fix the bug with uncontrolled framerate on Linux
+// https://bugs.openjdk.java.net/browse/JDK-8181764
+
+public class IOClientLauncher {
+    public static void main(String... args) {
+        System.setProperty("quantum.multithreaded", "false");
+        Application.launch(IOClient.class, args);
+    }
+}


### PR DESCRIPTION
Fix bug with uncontrolled framerate by setting "quantum.multithreaded"
system property to false before launching the application.

Fixes https://github.com/anstkras/IO/issues/1